### PR TITLE
fixed linkedin link

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         </div>
         <div class="social-icons">
             <a href="https://github.com/itsaryanjain" target="_blank"><i class="fab fa-github"></i></a>
-            <a href="www.linkedin.com/in/aryan-jain-98a309249" target="_blank"><i class="fab fa-linkedin"></i></a>
+            <a href="https://www.linkedin.com/in/aryan-jain-98a309249" target="_blank"><i class="fab fa-linkedin"></i></a>
             <a href="" target="_blank"><i class="fab fa-twitter"></i></a>
             <a href="https://www.instagram.com/aryaan.jainn?igsh=MXJjNmptcW9yeHR3eA%3D%3D&utm_source=qr" target="_blank"><i class="fab fa-instagram"></i></a>
         </div>


### PR DESCRIPTION
linkedin link opens to relative link on the portfolio site only. added an https:// so it opens as an absolute